### PR TITLE
Add basic shop/cart controllers

### DIFF
--- a/langs/en_US/externalaccess.lang
+++ b/langs/en_US/externalaccess.lang
@@ -241,3 +241,13 @@ invalidDomain = Invalid domain name
 EACCESS_FOLLOW_UP_EMAIL = Activate or deactivate the email field for ticket follow-up
 EACCESS_SEVERITY = Enable or disable the severity field on the ticket form
 EACCESS_DISABLE_SEVERITY_ON_TICKET = Disable severity display for tickets
+
+ViewProducts = Products
+ViewProductsDesc = Browse products
+Cart = Cart
+CartDesc = Manage your cart
+Checkout = Checkout
+CheckoutDesc = Place your order
+AddToCart = Add to cart
+CartEmpty = Your cart is empty
+OrderCreated = Order created

--- a/langs/fr_FR/externalaccess.lang
+++ b/langs/fr_FR/externalaccess.lang
@@ -251,3 +251,13 @@ VirtualHostsExtraFields = Attributs supplémentaires Hôte virtuel
 VirtalHostMapping = Hôtes virtuels
 EAVirtualHosts = Hôtes virtuels
 invalidDomain = Nom de domaine invalide
+
+ViewProducts=Produits
+ViewProductsDesc=Consultez le catalogue de produits
+Cart=Panier
+CartDesc=Gérez votre panier
+Checkout=Commander
+CheckoutDesc=Validez votre panier
+AddToCart=Ajouter au panier
+CartEmpty=Votre panier est vide
+OrderCreated=Commande créée

--- a/www/class/context.class.php
+++ b/www/class/context.class.php
@@ -147,10 +147,13 @@ class Context
 		$this->addControllerDefinition('projects', $defaultControllersPath.'projects.controller.php', 'ProjectsController');
 		$this->addControllerDefinition('tasks', $defaultControllersPath.'tasks.controller.php', 'TasksController');
 		$this->addControllerDefinition('expeditions', $defaultControllersPath.'expeditions.controller.php', 'ExpeditionsController');
-		$this->addControllerDefinition('supplier_invoices', $defaultControllersPath.'supplier_invoices.controller.php', 'SupplierInvoicesController');
-		$this->addControllerDefinition('tickets', $defaultControllersPath.'tickets.controller.php', 'TicketsController');
+                $this->addControllerDefinition('supplier_invoices', $defaultControllersPath.'supplier_invoices.controller.php', 'SupplierInvoicesController');
+                $this->addControllerDefinition('tickets', $defaultControllersPath.'tickets.controller.php', 'TicketsController');
+                $this->addControllerDefinition('products', $defaultControllersPath.'products.controller.php', 'ProductsController');
+                $this->addControllerDefinition('cart', $defaultControllersPath.'cart.controller.php', 'CartController');
+                $this->addControllerDefinition('checkout', $defaultControllersPath.'checkout.controller.php', 'CheckoutController');
 
-		// Appel des triggers
+                // Appel des triggers
 		include_once DOL_DOCUMENT_ROOT . '/core/class/interfaces.class.php';
 		$interface=new Interfaces($db);
 		$interface->run_triggers('externalAccessInitController', $this, $user, $langs, $conf);

--- a/www/controllers/cart.controller.php
+++ b/www/controllers/cart.controller.php
@@ -1,0 +1,80 @@
+<?php
+class CartController extends Controller
+{
+    public function checkAccess()
+    {
+        global $conf, $user;
+        $this->accessRight = isModEnabled('product') && getDolGlobalInt('EACCESS_ACTIVATE_PRODUCTS') && $user->hasRight('externalaccess', 'view_products');
+        return parent::checkAccess();
+    }
+
+    public function action()
+    {
+        global $langs;
+        $context = Context::getInstance();
+        if (!$context->controllerInstance->checkAccess()) { return; }
+
+        $context->title = $langs->trans('Cart');
+        $context->desc  = $langs->trans('CartDesc');
+        $context->menu_active[] = 'cart';
+
+        if ($context->action == 'add') {
+            $pid = GETPOST('pid', 'int');
+            $qty = GETPOST('qty', 'int');
+            if ($pid > 0) {
+                if (empty($_SESSION['cart_lines'][$pid])) $_SESSION['cart_lines'][$pid] = 0;
+                if ($qty <= 0) $qty = 1;
+                $_SESSION['cart_lines'][$pid] += $qty;
+                $context->setEventMessages($langs->trans('AddedToCart'), 'mesgs');
+            }
+        } elseif ($context->action == 'remove') {
+            $pid = GETPOST('pid', 'int');
+            unset($_SESSION['cart_lines'][$pid]);
+        } elseif ($context->action == 'update' && !empty($_POST['qty'])) {
+            foreach ($_POST['qty'] as $pid => $qty) {
+                $qty = intval($qty);
+                if ($qty <= 0) unset($_SESSION['cart_lines'][$pid]);
+                else $_SESSION['cart_lines'][$pid] = $qty;
+            }
+            $context->setEventMessages($langs->trans('Saved'), 'mesgs');
+        }
+    }
+
+    public function display()
+    {
+        $context = Context::getInstance();
+        if (!$context->controllerInstance->checkAccess()) { return $this->display404(); }
+
+        $this->loadTemplate('header');
+        $this->loadTemplate('cart');
+        $this->loadTemplate('footer');
+    }
+
+    public function getLines()
+    {
+        global $db;
+        dol_include_once('product/class/product.class.php');
+        $lines = array();
+        if (!empty($_SESSION['cart_lines'])) {
+            foreach ($_SESSION['cart_lines'] as $pid => $qty) {
+                $prod = new Product($db);
+                if ($prod->fetch($pid) > 0) {
+                    $line = new stdClass();
+                    $line->product = $prod;
+                    $line->qty = $qty;
+                    $lines[$pid] = $line;
+                }
+            }
+        }
+        return $lines;
+    }
+
+    public function getTotal()
+    {
+        $total = 0;
+        foreach ($this->getLines() as $line) {
+            $total += $line->product->price * $line->qty;
+        }
+        return $total;
+    }
+}

--- a/www/controllers/checkout.controller.php
+++ b/www/controllers/checkout.controller.php
@@ -1,0 +1,60 @@
+<?php
+class CheckoutController extends Controller
+{
+    public function checkAccess()
+    {
+        global $conf, $user;
+        $this->accessRight = isModEnabled('commande') && isModEnabled('product') && getDolGlobalInt('EACCESS_ACTIVATE_PRODUCTS') && $user->hasRight('externalaccess', 'view_products');
+        return parent::checkAccess();
+    }
+
+    public function action()
+    {
+        global $langs, $user, $db;
+        $context = Context::getInstance();
+        if (!$context->controllerInstance->checkAccess()) { return; }
+
+        $context->title = $langs->trans('Checkout');
+        $context->desc  = $langs->trans('CheckoutDesc');
+        $context->menu_active[] = 'checkout';
+
+        if ($context->action == 'placeorder' && !empty($_SESSION['cart_lines'])) {
+            dol_include_once('commande/class/commande.class.php');
+            dol_include_once('product/class/product.class.php');
+            $order = new Commande($db);
+            $order->socid = $user->socid;
+            $order->date_commande = dol_now();
+            foreach ($_SESSION['cart_lines'] as $pid => $qty) {
+                $prod = new Product($db);
+                if ($prod->fetch($pid) > 0) {
+                    $order->addline($prod->description, $prod->price, $qty, $prod->tva_tx, 0, 0, $pid, 0, 0, '', 0, 0, null, '', $prod->price_ttc, 0, '', $prod->fk_unit);
+                }
+            }
+            if ($order->create($user) > 0) {
+                $_SESSION['cart_lines'] = array();
+                $context->setEventMessages($langs->trans('OrderCreated'), 'mesgs');
+                header('Location: '.$context->getControllerUrl('orders'));
+                exit;
+            } else {
+                $context->setEventMessages($order->error, 'errors');
+            }
+        }
+    }
+
+    public function display()
+    {
+        $context = Context::getInstance();
+        if (!$context->controllerInstance->checkAccess()) { return $this->display404(); }
+
+        $this->loadTemplate('header');
+        $this->loadTemplate('checkout');
+        $this->loadTemplate('footer');
+    }
+
+    public function getLines()
+    {
+        require_once __DIR__.'/cart.controller.php';
+        $cart = new CartController();
+        return $cart->getLines();
+    }
+}

--- a/www/controllers/products.controller.php
+++ b/www/controllers/products.controller.php
@@ -1,0 +1,51 @@
+<?php
+class ProductsController extends Controller
+{
+    public function checkAccess()
+    {
+        global $conf, $user;
+        $this->accessRight = isModEnabled('product') && getDolGlobalInt('EACCESS_ACTIVATE_PRODUCTS') && $user->hasRight('externalaccess', 'view_products');
+        return parent::checkAccess();
+    }
+
+    public function action()
+    {
+        global $langs;
+        $context = Context::getInstance();
+        if (!$context->controllerInstance->checkAccess()) { return; }
+
+        $context->title = $langs->trans('ViewProducts');
+        $context->desc  = $langs->trans('ViewProductsDesc');
+        $context->menu_active[] = 'products';
+    }
+
+    public function display()
+    {
+        $context = Context::getInstance();
+        if (!$context->controllerInstance->checkAccess()) { return $this->display404(); }
+
+        $this->loadTemplate('header');
+        $this->loadTemplate('product_list');
+        $this->loadTemplate('footer');
+    }
+
+    public function getProducts()
+    {
+        global $db;
+        dol_include_once('product/class/product.class.php');
+
+        $sql = 'SELECT rowid FROM '.MAIN_DB_PREFIX.'product';
+        $sql .= ' WHERE entity IN ('.getEntity('product').') AND tosell = 1';
+        $res = $db->query($sql);
+        $products = array();
+        if ($res) {
+            while ($obj = $db->fetch_object($res)) {
+                $prod = new Product($db);
+                if ($prod->fetch($obj->rowid) > 0) {
+                    $products[] = $prod;
+                }
+            }
+        }
+        return $products;
+    }
+}

--- a/www/tpl/cart.tpl.php
+++ b/www/tpl/cart.tpl.php
@@ -1,0 +1,34 @@
+<?php
+if (empty($context) || ! is_object($context))
+{
+    print "Error, template page can't be called as URL";
+    exit;
+}
+
+global $langs;
+$lines = $context->controllerInstance->getLines();
+print '<section id="section-cart" class="type-content"><div class="container">';
+if (empty($lines)) {
+    print '<div class="info text-center">'.$langs->trans('CartEmpty').'</div>';
+} else {
+    print '<form method="post" action="'.$context->getControllerUrl('cart').'&action=update">';
+    print '<table class="table table-striped">';
+    print '<thead><tr><th>'.$langs->trans('Product').'</th><th class="text-right">'.$langs->trans('Qty').'</th><th class="text-right">'.$langs->trans('PriceUHT').'</th><th class="text-right">'.$langs->trans('TotalHT').'</th><th></th></tr></thead><tbody>';
+    foreach ($lines as $l) {
+        $p = $l->product;
+        $qty = $l->qty;
+        print '<tr>';
+        print '<td>'.$p->ref.' - '.dol_escape_htmltag($p->label).'</td>';
+        print '<td class="text-right"><input type="number" class="form-control form-control-sm" name="qty['.$p->id.']" value="'.$qty.'" min="0"/></td>';
+        print '<td class="text-right">'.price($p->price).'</td>';
+        print '<td class="text-right">'.price($p->price * $qty).'</td>';
+        print '<td class="text-right"><a class="btn btn-sm btn-danger" href="'.$context->getControllerUrl('cart','remove&pid='.$p->id).'"><i class="fa fa-trash"></i></a></td>';
+        print '</tr>';
+    }
+    print '<tr><td colspan="3" class="text-right"><strong>'.$langs->trans('Total').'</strong></td><td class="text-right"><strong>'.price($context->controllerInstance->getTotal()).'</strong></td><td></td></tr>';
+    print '</tbody></table>';
+    print '<div class="text-right"><button class="btn btn-primary" type="submit">'.$langs->trans('Save').'</button> ';
+    print '<a class="btn btn-success" href="'.$context->getControllerUrl('checkout').'">'.$langs->trans('Validate').'</a></div>';
+    print '</form>';
+}
+print '</div></section>';

--- a/www/tpl/checkout.tpl.php
+++ b/www/tpl/checkout.tpl.php
@@ -1,0 +1,17 @@
+<?php
+if (empty($context) || ! is_object($context))
+{
+    print "Error, template page can't be called as URL";
+    exit;
+}
+
+global $langs;
+$lines = $context->controllerInstance->getLines();
+print '<section id="section-checkout" class="type-content"><div class="container">';
+if (empty($lines)) {
+    print '<div class="info text-center">'.$langs->trans('CartEmpty').'</div>';
+} else {
+    print '<h3>'.$langs->trans('Checkout').'</h3>';
+    print '<p class="text-center"><a class="btn btn-success" href="'.$context->getControllerUrl('checkout','placeorder').'">'.$langs->trans('Validate').'</a></p>';
+}
+print '</div></section>';

--- a/www/tpl/product_list.tpl.php
+++ b/www/tpl/product_list.tpl.php
@@ -1,0 +1,28 @@
+<?php
+if (empty($context) || ! is_object($context))
+{
+    print "Error, template page can't be called as URL";
+    exit;
+}
+
+global $langs;
+$products = $context->controllerInstance->getProducts();
+print '<section id="section-products" class="type-content"><div class="container">';
+if (empty($products)) {
+    print '<div class="info text-center">'.$langs->trans('SorryThereIsNothingHere').'</div>';
+} else {
+    print '<div class="row">';
+    foreach ($products as $p) {
+        print '<div class="col-md-4 mb-4">';
+        print '<div class="card h-100 text-center">';
+        print '<img class="card-img-top p-3" src="'.getProductImgUrl($p->id, 'thumb').'" alt="">';
+        print '<div class="card-body">';
+        print '<h5 class="card-title">'.dol_escape_htmltag($p->ref).'</h5>';
+        print '<p class="card-text">'.dol_escape_htmltag($p->label).'</p>';
+        print '<p class="card-text"><strong>'.price($p->price).'</strong></p>';
+        print '<a class="btn btn-primary btn-strong" href="'.$context->getControllerUrl('cart', 'add&pid='.$p->id).'"><i class="fa fa-cart-plus"></i> '.$langs->trans('AddToCart').'</a>';
+        print '</div></div></div>';
+    }
+    print '</div>';
+}
+print '</div></section>';

--- a/www/tpl/services.tpl.php
+++ b/www/tpl/services.tpl.php
@@ -52,6 +52,12 @@ if(empty($reshook)){
         printService($langs->trans('Invoices'),'fa-file-text',$link); // desc : $langs->trans('InvoicesDesc')
     }
 
+    $link = $context->getControllerUrl('products');
+    printService($langs->trans('ViewProducts'),'fa-shopping-cart',$link);
+
+    $link = $context->getControllerUrl('cart');
+    printService($langs->trans('Cart'),'fa-cart-arrow-down',$link);
+
     if(getDolGlobalInt("EACCESS_ACTIVATE_TICKETS") && isModEnabled('ticket') && $user->hasRight('externalaccess', 'view_tickets')){
         $link = $context->getControllerUrl('tickets');
         printService($langs->trans('Tickets'),'fa-ticket',$link);


### PR DESCRIPTION
## Summary
- add ProductsController, CartController and CheckoutController for shop features
- show product catalog, cart and checkout templates
- expose shop links in services list
- register new controllers in context
- add translation strings

## Testing
- `php` not installed so syntax not checked

------
https://chatgpt.com/codex/tasks/task_e_6840569105c48324afe0370cc827761d