### PR TITLE
Add cart summary to checkout and update products permission

### DIFF
--- a/core/modules/modExternalAccess.class.php
+++ b/core/modules/modExternalAccess.class.php
@@ -246,6 +246,12 @@ class modExternalAccess extends DolibarrModules
 		$this->rights[$r][4] = 'view_tasks';				// In php code, permission will be checked by test if ($user->hasRight('permkey', 'level1', 'level2'))
 		$this->rights[$r][5] = '';				// In php code, permission will be checked by test if ($user->hasRight('permkey', 'level1', 'level2'))
 		$r++;
+		$this->rights[$r][0] = $this->numero . $r; // Permission id (unique)
+		$this->rights[$r][1] = 'external_access_products'; // Permission label
+		$this->rights[$r][3] = 0; // Default for new user
+		$this->rights[$r][4] = 'view_products'; // Permission code used in controllers
+                $this->rights[$r][5] = '';
+		$r++;
 
 		// Main menu entries
 		$this->menu = array();			// List of menus to add

--- a/langs/en_US/externalaccess.lang
+++ b/langs/en_US/externalaccess.lang
@@ -31,6 +31,8 @@ external_access_expeditions = can view shipments
 external_access_tickets = can view tickets 
 external_access_projets = can view projects
 external_access_userinfos_edit = can modify personal information
+external_access_products = can view products
+PermissionExternalAccessProducts = View products
 
 # MENU 
 TopMenuexternalaccess = External Access

--- a/langs/fr_FR/externalaccess.lang
+++ b/langs/fr_FR/externalaccess.lang
@@ -21,6 +21,8 @@ external_access_userinfos_edit= Modifier ses informations personnelles
 external_access_projets = Consulter ses projets
 external_access_tasks = Consulter les tâches de ses projets
 external_access_supplier_invoices= Consulter ses factures fournisseurs
+external_access_products= Consulter les produits
+PermissionExternalAccessProducts=Consulter les produits
 
 # MENU
 TopMenuexternalaccess=Portail client

--- a/www/controllers/checkout.controller.php
+++ b/www/controllers/checkout.controller.php
@@ -46,6 +46,8 @@ class CheckoutController extends Controller
         $context = Context::getInstance();
         if (!$context->controllerInstance->checkAccess()) { return $this->display404(); }
 
+        $context->lines = $this->getLines();
+
         $this->loadTemplate('header');
         $this->loadTemplate('checkout');
         $this->loadTemplate('footer');
@@ -53,8 +55,20 @@ class CheckoutController extends Controller
 
     public function getLines()
     {
-        require_once __DIR__.'/cart.controller.php';
-        $cart = new CartController();
-        return $cart->getLines();
+        global $db;
+        dol_include_once('product/class/product.class.php');
+        $lines = array();
+        if (!empty($_SESSION['cart_lines'])) {
+            foreach ($_SESSION['cart_lines'] as $pid => $qty) {
+                $prod = new Product($db);
+                if ($prod->fetch($pid) > 0) {
+                    $line = new stdClass();
+                    $line->product = $prod;
+                    $line->qty = $qty;
+                    $lines[$pid] = $line;
+                }
+            }
+        }
+        return $lines;
     }
 }

--- a/www/tpl/checkout.tpl.php
+++ b/www/tpl/checkout.tpl.php
@@ -6,12 +6,31 @@ if (empty($context) || ! is_object($context))
 }
 
 global $langs;
-$lines = $context->controllerInstance->getLines();
+$lines = $context->lines;
 print '<section id="section-checkout" class="type-content"><div class="container">';
 if (empty($lines)) {
     print '<div class="info text-center">'.$langs->trans('CartEmpty').'</div>';
 } else {
     print '<h3>'.$langs->trans('Checkout').'</h3>';
-    print '<p class="text-center"><a class="btn btn-success" href="'.$context->getControllerUrl('checkout','placeorder').'">'.$langs->trans('Validate').'</a></p>';
+    print '<form method="post" action="'.$context->getControllerUrl('checkout','confirm').'">';
+    print '<table class="table table-striped">';
+    print '<thead><tr><th>'.$langs->trans('Product').'</th><th class="text-right">'.$langs->trans('Qty').'</th><th class="text-right">'.$langs->trans('PriceUHT').'</th><th class="text-right">'.$langs->trans('TotalHT').'</th></tr></thead><tbody>';
+    $total = 0;
+    foreach ($lines as $l) {
+        $p = $l->product;
+        $qty = $l->qty;
+        $lineTotal = $p->price * $qty;
+        $total += $lineTotal;
+        print '<tr>';
+        print '<td>'.$p->ref.' - '.dol_escape_htmltag($p->label).'</td>';
+        print '<td class="text-right">'.$qty.'</td>';
+        print '<td class="text-right">'.price($p->price).'</td>';
+        print '<td class="text-right">'.price($lineTotal).'</td>';
+        print '</tr>';
+    }
+    print '<tr><td colspan="3" class="text-right"><strong>'.$langs->trans('Total').'</strong></td><td class="text-right"><strong>'.price($total).'</strong></td></tr>';
+    print '</tbody></table>';
+    print '<div class="text-right"><button class="btn btn-success" type="submit">'.$langs->trans('Validate').'</button></div>';
+    print '</form>';
 }
 print '</div></section>';


### PR DESCRIPTION
## Summary
- show cart lines in checkout and submit to confirm
- expose lines in CheckoutController
- allow viewing products with new permission labels

## Testing
- `php -l www/controllers/checkout.controller.php`
- `php -l www/tpl/checkout.tpl.php`


------
https://chatgpt.com/codex/tasks/task_e_68408803e28083248b7ca9271cfbb55f